### PR TITLE
`rstruct FFI`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,1 @@
-
+mod structs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,1 @@
-mod structs;
+pub mod structs;

--- a/src/structs/color.rs
+++ b/src/structs/color.rs
@@ -1,0 +1,7 @@
+#[repr(C)]
+pub struct Color {
+  pub red: u8,
+  pub green: u8,
+  pub blue: u8,
+  pub alpha: u8,
+}

--- a/src/structs/mod.rs
+++ b/src/structs/mod.rs
@@ -1,0 +1,1 @@
+mod color;

--- a/src/structs/mod.rs
+++ b/src/structs/mod.rs
@@ -1,1 +1,3 @@
 mod color;
+
+pub use color::Color;


### PR DESCRIPTION
Add required `rstruct` structs to start `basic_window` example inside `Rust` language.