### PR TITLE
`rconst FFI`

### DIFF
--- a/src/consts/colors.rs
+++ b/src/consts/colors.rs
@@ -1,0 +1,8 @@
+use crate::structs::Color;
+
+pub const RAYWHITE: Color = Color {
+  red: 245,
+  green: 245,
+  blue: 245,
+  alpha: 255,
+};

--- a/src/consts/colors.rs
+++ b/src/consts/colors.rs
@@ -1,5 +1,12 @@
 use crate::structs::Color;
 
+pub const LIGHTGRAY: Color = Color {
+  red: 200,
+  green: 200,
+  blue: 200,
+  alpha: 200,
+};
+
 pub const RAYWHITE: Color = Color {
   red: 245,
   green: 245,

--- a/src/consts/mod.rs
+++ b/src/consts/mod.rs
@@ -1,0 +1,1 @@
+mod colors;

--- a/src/consts/mod.rs
+++ b/src/consts/mod.rs
@@ -1,3 +1,3 @@
 mod colors;
 
-pub use colors::RAYWHITE;
+pub use colors::*;

--- a/src/consts/mod.rs
+++ b/src/consts/mod.rs
@@ -1,1 +1,3 @@
 mod colors;
+
+pub use colors::RAYWHITE;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,1 @@
-
+pub mod consts;


### PR DESCRIPTION
Add required `rconst` objects to start `basic_window` example inside `Rust` language.